### PR TITLE
Fix wrong path to MLP CSS

### DIFF
--- a/resources/css/main.css
+++ b/resources/css/main.css
@@ -2,7 +2,7 @@
 @import "media-library-pro-styles";
 
 /* Option 2: use package styles but build with tailwind config from app */
-/* @import "./../../vendor/spatie/laravel-medialibrary-pro/resources/js/medialibrary-pro-styles/src/styles.css"; */
+/* @import "./../../vendor/spatie/laravel-media-library-pro/resources/js/medialibrary-pro-styles/src/styles.css"; */
 
 /* Option 3: edit styles */
 /* @import "./media-library-pro/styles.css"; */


### PR DESCRIPTION
I can't get this to work:

    @import "media-library-pro-styles";

so I was reading the alternatives in this file, and noticed that the alternative loading mechanism has a wrong path to the `media-library-pro-styles` folder that's actually created in vendor. I know you had a renaming from `medialibrary` to `media-library` recently, so I guess this instance escaped the update.